### PR TITLE
move state ownership from modules to application

### DIFF
--- a/examples/basic_tf_stub/src/basic_tf_stub.cc
+++ b/examples/basic_tf_stub/src/basic_tf_stub.cc
@@ -291,6 +291,14 @@ ns_audio_config_t audio_config = {
     #endif
 };
 
+#ifdef RPC_ENABLED
+ns_rpc_config_t rpcConfig =  {
+            .mode = NS_RPC_GENERICDATA_CLIENT,
+            .sendBlockToEVB_cb = NULL,
+            .fetchBlockFromEVB_cb = NULL,
+            .computeOnEVB_cb = NULL
+        };
+#endif
 /**
  * @brief Main function - infinite loop listening and inferring
  * 
@@ -352,13 +360,6 @@ main(void) {
             .description = msg_store,
             .cmd = write_cmd,
             .buffer = binaryBlock
-        };
-
-        ns_rpc_config_t rpcConfig = {
-            .mode = NS_RPC_GENERICDATA_CLIENT,
-            .sendBlockToEVB_cb = NULL,
-            .fetchBlockFromEVB_cb = NULL,
-            .computeOnEVB_cb = NULL
         };
         ns_rpc_genericDataOperations_init(&rpcConfig); // init RPC and USB
 

--- a/examples/har/src/har.cc
+++ b/examples/har/src/har.cc
@@ -21,6 +21,12 @@
 #define NUMSAMPLES 32
 #define AXES 3
 float g_sensorData[NUMSAMPLES*2][7]; // 32 samples of gryo, accel and temp 
+ns_rpc_config_t rpcConfig = {
+        .mode = NS_RPC_GENERICDATA_CLIENT,
+        .sendBlockToEVB_cb = NULL,
+        .fetchBlockFromEVB_cb = NULL,
+        .computeOnEVB_cb = NULL
+    };
 
 int
 main(void) {
@@ -60,12 +66,6 @@ main(void) {
     };
 
     // Initialize the Generic RPC Client interface
-    ns_rpc_config_t rpcConfig = {
-        .mode = NS_RPC_GENERICDATA_CLIENT,
-        .sendBlockToEVB_cb = NULL,
-        .fetchBlockFromEVB_cb = NULL,
-        .computeOnEVB_cb = NULL
-    };
     ns_rpc_genericDataOperations_init(&rpcConfig); // inits RPC and USB
 
     // Button global - will be set by neuralSPOT button helper

--- a/examples/mpu_data_collection/src/mpu_data_collection.cc
+++ b/examples/mpu_data_collection/src/mpu_data_collection.cc
@@ -22,6 +22,12 @@
 #define NUMSAMPLES 32
 #define AXES 3
 float g_sensorData[NUMSAMPLES*2][7]; // 32 samples of gryo, accel and temp 
+ns_rpc_config_t rpcConfig = {
+        .mode = NS_RPC_GENERICDATA_CLIENT,
+        .sendBlockToEVB_cb = NULL,
+        .fetchBlockFromEVB_cb = NULL,
+        .computeOnEVB_cb = NULL
+    };
 
 int
 main(void) {
@@ -56,12 +62,6 @@ main(void) {
     };
 
     // Initialize the Generic RPC Client interface
-    ns_rpc_config_t rpcConfig = {
-        .mode = NS_RPC_GENERICDATA_CLIENT,
-        .sendBlockToEVB_cb = NULL,
-        .fetchBlockFromEVB_cb = NULL,
-        .computeOnEVB_cb = NULL
-    };
     ns_rpc_genericDataOperations_init(&rpcConfig); // inits RPC and USB
 
     // Button global - will be set by neuralSPOT button helper

--- a/examples/rpc_client_example/src/rpc_client.cc
+++ b/examples/rpc_client_example/src/rpc_client.cc
@@ -59,7 +59,12 @@ ns_audio_config_t audioConfig = {
     .bufferHandle = NULL
 };
 // -- Audio Stuff Ends ----------------------
-
+ns_rpc_config_t rpcConfig = {
+        .mode = NS_RPC_GENERICDATA_CLIENT,
+        .sendBlockToEVB_cb = NULL,
+        .fetchBlockFromEVB_cb = NULL,
+        .computeOnEVB_cb = NULL
+    };
 int main(void) {
     ns_itm_printf_enable();
     ns_debug_printf_enable();
@@ -110,12 +115,6 @@ int main(void) {
         .buffer = binaryBlock
     };
 
-    ns_rpc_config_t rpcConfig = {
-        .mode = NS_RPC_GENERICDATA_CLIENT,
-        .sendBlockToEVB_cb = NULL,
-        .fetchBlockFromEVB_cb = NULL,
-        .computeOnEVB_cb = NULL
-    };
     // Result of computation
     dataBlock resultBlock;
     ns_rpc_genericDataOperations_init(&rpcConfig); // init RPC and USB

--- a/examples/rpc_server_example/src/rpc_server.cc
+++ b/examples/rpc_server_example/src/rpc_server.cc
@@ -112,6 +112,12 @@ status example_computeOnEVB(const dataBlock * in, dataBlock * res) {
 
     return ns_rpc_data_success;      
 }
+ns_rpc_config_t rpcConfig = {
+        .mode = NS_RPC_GENERICDATA_SERVER,  // Puts EVB in RPC server mode
+        .sendBlockToEVB_cb = example_sendBlockToEVB,
+        .fetchBlockFromEVB_cb = example_fetchBlockFromEVB,
+        .computeOnEVB_cb = example_computeOnEVB
+    };
 
 int main(void) {
     ns_itm_printf_enable();
@@ -133,12 +139,6 @@ int main(void) {
     ns_peripheral_button_init(&button_config);
 
     // Add callbacks to handle incoming requests
-    ns_rpc_config_t rpcConfig = {
-        .mode = NS_RPC_GENERICDATA_SERVER,  // Puts EVB in RPC server mode
-        .sendBlockToEVB_cb = example_sendBlockToEVB,
-        .fetchBlockFromEVB_cb = example_fetchBlockFromEVB,
-        .computeOnEVB_cb = example_computeOnEVB
-    };
     ns_rpc_genericDataOperations_init(&rpcConfig);
 
     ns_printf("Start the PC-side client, then press Button 0 to get started\n");

--- a/neuralspot/ns-audio/includes-api/ns_audio.h
+++ b/neuralspot/ns-audio/includes-api/ns_audio.h
@@ -105,7 +105,7 @@ typedef struct am_ai_acfg {
 
 } ns_audio_config_t;
 
-extern ns_audio_config_t g_ns_audio_config;
+extern ns_audio_config_t *g_ns_audio_config;
 
 /**
  * @brief Initialize NeuralSPOT audio capture library

--- a/neuralspot/ns-audio/src/ns_audadc.c
+++ b/neuralspot/ns-audio/src/ns_audadc.c
@@ -391,7 +391,7 @@ am_audadc0_isr(void) {
                 else
                     *am_ai_sampleReadyFlag = true;
             }*/
-            g_ns_audio_config.callback(&g_ns_audio_config, 0);
+            g_ns_audio_config->callback(g_ns_audio_config, 0);
         }
     }
 
@@ -425,7 +425,7 @@ audadc_init() {
     // AUDADC DMA data config:
     //   DMA buffers padded at 16B alignment.
     //
-    g_sAUDADCDMAConfig.ui32SampleCount = g_ns_audio_config.numSamples;
+    g_sAUDADCDMAConfig.ui32SampleCount = g_ns_audio_config->numSamples;
 
     uint32_t ui32AUDADCDataPtr =
         (uint32_t)((uint32_t)(g_ui32AUDADCSampleBuffer + 3) & ~0xF);
@@ -459,7 +459,7 @@ audadc_init() {
     // Configure the AUDADC
     //
     audadc_config();
-    g_ns_audio_config.audioSystemHandle =
+    g_ns_audio_config->audioSystemHandle =
         g_AUDADCHandle; // wait for it to have real value
 
     // Gain setting

--- a/neuralspot/ns-audio/src/ns_audio.c
+++ b/neuralspot/ns-audio/src/ns_audio.c
@@ -45,40 +45,25 @@ uint32_t g_ui32SampleToRTT = 0;
  * isn't valid until futher initialized by ns_audio_init
  *
  */
-ns_audio_config_t g_ns_audio_config = {.eAudioApiMode = NS_AUDIO_API_CALLBACK,
-                                       .callback = NULL,
-                                       .audioBuffer = NULL,
-                                       .eAudioSource = NS_AUDIO_SOURCE_AUDADC,
-                                       .numChannels = 1,
-                                       .numSamples = 480,
-                                       .sampleRate = 16000,
-                                       .audioSystemHandle = NULL,
-                                       .bufferHandle = NULL};
+ns_audio_config_t *g_ns_audio_config;
 
 void ns_audio_init(ns_audio_config_t *cfg) {
     // Copy in config
-    g_ns_audio_config.eAudioApiMode = cfg->eAudioApiMode;
-    g_ns_audio_config.callback = cfg->callback;
-    g_ns_audio_config.callback = cfg->callback;
-    g_ns_audio_config.audioBuffer = cfg->audioBuffer;
-    g_ns_audio_config.numChannels = cfg->numChannels;
-    g_ns_audio_config.numSamples = cfg->numSamples;
-    g_ns_audio_config.sampleRate = cfg->sampleRate;
-    g_ns_audio_config.eAudioSource = cfg->eAudioSource;
+    g_ns_audio_config = cfg;
 
-    if (g_ns_audio_config.eAudioApiMode == NS_AUDIO_API_RINGBUFFER) {
+    if (g_ns_audio_config->eAudioApiMode == NS_AUDIO_API_RINGBUFFER) {
         // init a ringbuffer
         ns_ipc_ringbuff_setup_t setup = {
             .indx = 0,
-            .pData = g_ns_audio_config.audioBuffer,
-            .ui32ByteSize = g_ns_audio_config.numSamples * 2 * 2
+            .pData = g_ns_audio_config->audioBuffer,
+            .ui32ByteSize = g_ns_audio_config->numSamples * 2 * 2
         };
 
         ns_ipc_ring_buffer_init(cfg->bufferHandle, setup);
-        g_ns_audio_config.bufferHandle = cfg->bufferHandle;
+        g_ns_audio_config->bufferHandle = cfg->bufferHandle;
     }
 
-    if (g_ns_audio_config.eAudioSource == NS_AUDIO_SOURCE_AUDADC) {
+    if (g_ns_audio_config->eAudioSource == NS_AUDIO_SOURCE_AUDADC) {
         audadc_init();
     }
 

--- a/neuralspot/ns-rpc/src/ns_rpc_generic_data.c
+++ b/neuralspot/ns-rpc/src/ns_rpc_generic_data.c
@@ -35,12 +35,7 @@ ns_usb_config_t g_RpcGenericUSBHandle = {
         .tx_cb = NULL
 };
 
-ns_rpc_config_t g_RpcGenericDataConfig = {
-    .mode = NS_RPC_GENERICDATA_CLIENT,
-    .sendBlockToEVB_cb = NULL,
-    .fetchBlockFromEVB_cb = NULL,
-    .computeOnEVB_cb = NULL
-};
+ns_rpc_config_t* g_RpcGenericDataConfig;
 
 // GenericDataOperations implements 3 function calls that service
 // remote calls from a PC. They must be instantiated to enable them.
@@ -48,8 +43,8 @@ ns_rpc_config_t g_RpcGenericDataConfig = {
 status ns_rpc_data_sendBlockToEVB(const dataBlock * block) {
     ns_printf("Received call to sendBlockToEVB\n");
 
-    if (g_RpcGenericDataConfig.sendBlockToEVB_cb != NULL) {
-        return g_RpcGenericDataConfig.sendBlockToEVB_cb(block);
+    if (g_RpcGenericDataConfig->sendBlockToEVB_cb != NULL) {
+        return g_RpcGenericDataConfig->sendBlockToEVB_cb(block);
     } else { 
         return ns_rpc_data_success;
     }
@@ -58,8 +53,8 @@ status ns_rpc_data_sendBlockToEVB(const dataBlock * block) {
 status ns_rpc_data_fetchBlockFromEVB(dataBlock * block) {
     ns_printf("Received call to fetchBlockFromEVB\n");
 
-    if (g_RpcGenericDataConfig.fetchBlockFromEVB_cb != NULL) {
-        return g_RpcGenericDataConfig.fetchBlockFromEVB_cb(block);
+    if (g_RpcGenericDataConfig->fetchBlockFromEVB_cb != NULL) {
+        return g_RpcGenericDataConfig->fetchBlockFromEVB_cb(block);
     } else { 
         return ns_rpc_data_success;
     }
@@ -68,8 +63,8 @@ status ns_rpc_data_fetchBlockFromEVB(dataBlock * block) {
 status ns_rpc_data_computeOnEVB(const dataBlock * in_block, dataBlock * result_block) {
     ns_printf("Received call to computeOnEVB\n");
 
-    if (g_RpcGenericDataConfig.computeOnEVB_cb != NULL) {
-        return g_RpcGenericDataConfig.computeOnEVB_cb(in_block, result_block);
+    if (g_RpcGenericDataConfig->computeOnEVB_cb != NULL) {
+        return g_RpcGenericDataConfig->computeOnEVB_cb(in_block, result_block);
     } else { 
         return ns_rpc_data_success;
     }
@@ -77,16 +72,13 @@ status ns_rpc_data_computeOnEVB(const dataBlock * in_block, dataBlock * result_b
 
 uint16_t ns_rpc_genericDataOperations_init(ns_rpc_config_t *cfg) {
 
-    usb_handle_t usb_handle = ns_usb_init(&g_RpcGenericUSBHandle);
+    ns_usb_init(&g_RpcGenericUSBHandle);
 
-    g_RpcGenericDataConfig.mode = cfg->mode;
-    g_RpcGenericDataConfig.sendBlockToEVB_cb = cfg->sendBlockToEVB_cb;
-    g_RpcGenericDataConfig.fetchBlockFromEVB_cb = cfg->fetchBlockFromEVB_cb;
-    g_RpcGenericDataConfig.computeOnEVB_cb = cfg->computeOnEVB_cb;
+    g_RpcGenericDataConfig = cfg;
 
     // Common ERPC init
     /* USB transport layer initialization */
-    erpc_transport_t transport = erpc_transport_usb_cdc_init(usb_handle);
+    erpc_transport_t transport = erpc_transport_usb_cdc_init((usb_handle_t*)&g_RpcGenericUSBHandle);
 
     /* MessageBufferFactory initialization */
     erpc_mbf_t message_buffer_factory = erpc_mbf_dynamic_init();

--- a/neuralspot/ns-usb/includes-api/ns_usb.h
+++ b/neuralspot/ns-usb/includes-api/ns_usb.h
@@ -48,8 +48,7 @@ typedef struct {
     ns_usb_tx_cb tx_cb;
 } ns_usb_config_t;
 
-extern usb_handle_t
-ns_usb_init(ns_usb_config_t *);
+extern void ns_usb_init(ns_usb_config_t *);
 
 extern void ns_usb_register_callbacks(usb_handle_t, ns_usb_rx_cb, ns_usb_tx_cb);
 

--- a/neuralspot/ns-usb/src/ns_usb.c
+++ b/neuralspot/ns-usb/src/ns_usb.c
@@ -14,24 +14,14 @@
 #include "ns_usb.h"
 #include "ns_ambiqsuite_harness.h"
 
-static ns_usb_config_t usb_config = {.deviceType = NS_USB_CDC_DEVICE,
-                                     .buffer = NULL,
-                                     .bufferLength = 0,
-                                     .rx_cb = NULL,
-                                     .tx_cb = NULL};
+static ns_usb_config_t *usb_config;
 
-usb_handle_t
+void
 ns_usb_init(ns_usb_config_t *cfg) {
 
-    usb_config.deviceType = cfg->deviceType;
-    usb_config.buffer = cfg->buffer;
-    usb_config.bufferLength = cfg->bufferLength;
-    usb_config.rx_cb = cfg->rx_cb;
-    usb_config.tx_cb = cfg->tx_cb;
+    usb_config = cfg;
 
     tusb_init();
-
-    return (void *)&usb_config; // TODO make this a better handle
 }
 
 void
@@ -48,12 +38,12 @@ void
 tud_cdc_rx_cb(uint8_t itf) {
     (void)itf;
     ns_usb_transaction_t rx;
-    if (usb_config.rx_cb != NULL) {
-        rx.handle = &usb_config;
-        rx.buffer = usb_config.buffer;
+    if (usb_config->rx_cb != NULL) {
+        rx.handle = usb_config;
+        rx.buffer = usb_config->buffer;
         rx.status = AM_HAL_STATUS_SUCCESS;
         rx.itf = itf;
-        usb_config.rx_cb(&rx);
+        usb_config->rx_cb(&rx);
     }
     gGotUSBRx = 1;
 }
@@ -62,12 +52,12 @@ void
 tud_cdc_tx_complete_cb(uint8_t itf) {
     (void)itf;
     ns_usb_transaction_t rx;
-    if (usb_config.tx_cb != NULL) {
-        rx.handle = &usb_config;
-        rx.buffer = usb_config.buffer;
+    if (usb_config->tx_cb != NULL) {
+        rx.handle = usb_config;
+        rx.buffer = usb_config->buffer;
         rx.status = AM_HAL_STATUS_SUCCESS;
         rx.itf = itf;
-        usb_config.tx_cb(&rx);
+        usb_config->tx_cb(&rx);
     }
 }
 


### PR DESCRIPTION
this PR is meant to change ownership of module state from the module to the application. This gives the application more control over memory management but does mean the application is responsible for not de-allocating these state variables.

I didn't make any changes to moving variables from global scope to static scope, but I can do that in another commit or another PR if wanted. 

I haven't tested this change. A consequence of this change is application developers need to make sure not to de-allocate their module config structs (don't pass config structs declared on the stack into init functions)