### PR TITLE
optimize the default voltage setting of measuing power

### DIFF
--- a/tools/autodeploy/measure_power.py
+++ b/tools/autodeploy/measure_power.py
@@ -251,7 +251,7 @@ def measurePower():
             device.close()
             device.open()
             device.parameter_set("reduction_frequency", "50 Hz")
-            device.parameter_set("io_voltage", "3.3V")
+            device.parameter_set("io_voltage", "1.8V")
             device.parameter_set("sensor_power", "on")
             device.parameter_set("i_range", "auto")
             device.parameter_set("v_range", "15V")


### PR DESCRIPTION
I found my EVB cannot trigger a rising interrupt after the joulescope output HIGH, changing the io setting of the joulescope from 3.3V to 1.8V can fix this issue, Apollo4x EVB system voltage work under 1.9V, so 1.8V might be a better default value. 